### PR TITLE
Update s3 keyprefix for nvidia drivers

### DIFF
--- a/GPU Updater Tool.ps1
+++ b/GPU Updater Tool.ps1
@@ -31,7 +31,7 @@ Else {
     }
 
 $Bucket = "nvidia-gaming"
-$KeyPrefix = "windows/latest"
+$KeyPrefix = "windows"
 $S3Objects = Get-S3Object -BucketName $Bucket -KeyPrefix $KeyPrefix -Region us-east-1 -ProfileName "$args"
 $S3Objects.key | select-string -Pattern 'win10_64bit' 
 }


### PR DESCRIPTION
Looks like the bucket contents have changed.

'windows/latest' now gets a zip file. This doesn't match the 'win10_64bit' pattern so the script errors out.

Setting the prefix to 'windows' get's a driver and seems to work fine but possibly the script should be updated to use the zip contents instead.

Bucket details:

```
PS C:\Users\Administrator> $S3Objects = Get-S3Object -BucketName "nvidia-gaming" -KeyPrefix "windows" -Region "us-east-1" -ProfileName "GPUUpdateG4Dn"
PS C:\Users\Administrator> $S3Objects.key
windows/
windows/440.48-441.87-grid-vgaming-jan2020-applicaton-note.pdf
windows/441.12_grid_vgaming_server2008R2_server2012R2_64bit_international.exe
windows/441.12_grid_vgaming_server2016_server2019_64bit_international.exe
windows/441.66-440.43-grid-vgaming-applicaton-note.pdf
windows/441.66_grid_vgaming_server2008R2_server2012R2_64bit_international.exe
windows/441.66_grid_vgaming_server2016_server2019_64bit_international.exe
windows/441.87_grid_vgaming_win10_64bit_international_whql.exe
windows/441.87_grid_vgaming_win8_win7_64bit_international_whql.exe
windows/latest/
windows/latest/GRID-442.19-Feb2020-vGaming-Windows-Guest-Drivers.zip
```